### PR TITLE
Remove obsolete version attribute from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
-version: '3.4'
+# the attribute `version` is obsolete
+# version: '3.4'
 
 services:
   shardeum-dashboard:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,3 @@
-# the attribute `version` is obsolete
-# version: '3.4'
-
 services:
   shardeum-dashboard:
     container_name: shardeum-dashboard


### PR DESCRIPTION
Fix:
WARN[0000] /root/.shardeum/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion