### PR TITLE
red-269 password min requirements

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -429,7 +429,7 @@ if [ "$CHANGEPASSWORD" == "y" ]; then
       DASHPASS=$(read_password)
       if (( ${#DASHPASS} < 8 )); then
           echo -n -e  "\nInvalid password!\n\n"
-      elif [ -z $(echo $DASHPASS | grep "[a-z]" | grep "[A-Z]" | grep "[0-9]" | grep "[!@#$%^&*()_+*$]")  ]; then
+      elif [ -z "$(echo $DASHPASS | grep "[a-z]" | grep "[A-Z]" | grep "[0-9]" | grep "[!@#$%^&*()_+*$]")"  ]; then
           echo -n -e  "\nInvalid password!\n\n"
       else
           valid_pass=true

--- a/installer.sh
+++ b/installer.sh
@@ -421,7 +421,7 @@ read_password() {
   echo $PASSWORD
 }
 
-if [ "$CHANGEPASSWORD" == "y" ]; then
+if [ "$CHANGEPASSWORD" = "y" ]; then
   valid_pass=false
   while [ "$valid_pass" = false ] ;
   do

--- a/installer.sh
+++ b/installer.sh
@@ -425,7 +425,7 @@ if [ "$CHANGEPASSWORD" = "y" ]; then
   valid_pass=false
   while [ "$valid_pass" = false ] ;
   do
-      echo -n -e "Password requirements: min 8 characters, at least 1 letter, at least 1 number, at least 1 special character \nSet the password to access the Dashboard:"
+      echo -n -e "Password requirements: min 8 characters, at least 1 letter, at least 1 number, at least 1 special character !@#$%^&*()_+*$ \nSet the password to access the Dashboard:"
       DASHPASS=$(read_password)
       if (( ${#DASHPASS} < 8 )); then
           echo -n -e  "\nInvalid password!\n\n"

--- a/installer.sh
+++ b/installer.sh
@@ -425,15 +425,34 @@ if [ "$CHANGEPASSWORD" = "y" ]; then
   valid_pass=false
   while [ "$valid_pass" = false ] ;
   do
-      echo -n -e "Password requirements: min 8 characters, at least 1 lower case letter, at least 1 upper case letter, at least 1 number, at least 1 special character !@#$%^&*()_+*$ \nSet the password to access the Dashboard:"
-      DASHPASS=$(read_password)
-      if (( ${#DASHPASS} < 8 )); then
-          echo -n -e  "\nInvalid password!\n\n"
-      elif [ -z "$(echo $DASHPASS | grep "[a-z]" | grep "[A-Z]" | grep "[0-9]" | grep "[!@#$%^&*()_+*$]")"  ]; then
-          echo -n -e  "\nInvalid password!\n\n"
-      else
-          valid_pass=true
-      fi
+    echo -n -e "Password requirements: min 8 characters, at least 1 lower case letter, at least 1 upper case letter, at least 1 number, at least 1 special character !@#$%^&*()_+*$ \nSet the password to access the Dashboard:"
+    DASHPASS=$(read_password)
+
+    # Check password length
+    if (( ${#DASHPASS} < 8 )); then
+        echo -e "\nInvalid password! Too short.\n"
+
+    # Check for at least one lowercase letter
+    elif ! [[ "$DASHPASS" =~ [a-z] ]]; then
+        echo -e "\nInvalid password! Must contain at least one lowercase letter.\n"
+
+    # Check for at least one uppercase letter
+    elif ! [[ "$DASHPASS" =~ [A-Z] ]]; then
+        echo -e "\nInvalid password! Must contain at least one uppercase letter.\n"
+
+    # Check for at least one number
+    elif ! [[ "$DASHPASS" =~ [0-9] ]]; then
+        echo -e "\nInvalid password! Must contain at least one number.\n"
+
+    # Check for at least one special character
+    elif ! [[ "$DASHPASS" =~ [!@#$%^\&*()_+*$] ]]; then
+        echo -e "\nInvalid password! Must contain at least one special character.\n"
+
+    # Password is valid
+    else
+        valid_pass=true
+        echo "Password set successfully."
+    fi
   done
 
   # Hash the password using the fallback mechanism

--- a/installer.sh
+++ b/installer.sh
@@ -425,7 +425,7 @@ if [ "$CHANGEPASSWORD" = "y" ]; then
   valid_pass=false
   while [ "$valid_pass" = false ] ;
   do
-    echo -n -e "Password requirements: min 8 characters, at least 1 lower case letter, at least 1 upper case letter, at least 1 number, at least 1 special character !@#$%^&*()_+*$ \nSet the password to access the Dashboard:"
+    echo -n -e "Password requirements: min 8 characters, at least 1 lower case letter, at least 1 upper case letter, at least 1 number, at least 1 special character !@#$%^&*()_+$ \nSet the password to access the Dashboard:"
     DASHPASS=$(read_password)
 
     # Check password length
@@ -445,8 +445,8 @@ if [ "$CHANGEPASSWORD" = "y" ]; then
         echo -e "\nInvalid password! Must contain at least one number.\n"
 
     # Check for at least one special character
-    elif ! [[ "$DASHPASS" =~ [!@#$%^\&*()_+*$] ]]; then
-        echo -e "\nInvalid password! Must contain at least one special character.\n"
+    elif ! [[ "$DASHPASS" =~ [!@#$%^\&*()_+$] ]]; then
+        echo -e "\nInvalid password! Must contain at least one special character !@#$%^&*()_+$.\n"
 
     # Password is valid
     else

--- a/installer.sh
+++ b/installer.sh
@@ -425,7 +425,7 @@ if [ "$CHANGEPASSWORD" = "y" ]; then
   valid_pass=false
   while [ "$valid_pass" = false ] ;
   do
-      echo -n -e "Password requirements: min 8 characters, at least 1 letter, at least 1 number, at least 1 special character !@#$%^&*()_+*$ \nSet the password to access the Dashboard:"
+      echo -n -e "Password requirements: min 8 characters, at least 1 lower case letter, at least 1 upper case letter, at least 1 number, at least 1 special character !@#$%^&*()_+*$ \nSet the password to access the Dashboard:"
       DASHPASS=$(read_password)
       if (( ${#DASHPASS} < 8 )); then
           echo -n -e  "\nInvalid password!\n\n"


### PR DESCRIPTION
Add validation for minimal password requirements 

installer script now requires: min 8 characters, at least 1 lower case letter, at least 1 upper case letter, at least 1 number, at least 1 special character !@#$%^&*()_+*$

this description was also added to the installer instructions 

Related PR's 
https://github.com/shardeum/validator-cli/pull/22
https://github.com/shardeum/validator-gui/pull/33