### PR TITLE
refac: proper indentation

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -451,7 +451,7 @@ if [ "$CHANGEPASSWORD" = "y" ]; then
     # Password is valid
     else
         valid_pass=true
-        echo "Password set successfully."
+        echo "\nPassword set successfully."
     fi
   done
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/276ea285-9207-4ae2-ba51-780bfedc0eb2)

`Password set successfully` should be printed on the next line. Looks unclean. 