### PR TITLE
remove obsolete version from docker-compose.tmpl

### DIFF
--- a/docker-compose.tmpl
+++ b/docker-compose.tmpl
@@ -1,5 +1,3 @@
-version: '3.4'
-
 services:
   shardeum-dashboard:
     container_name: shardeum-dashboard


### PR DESCRIPTION
> Fix:
WARN[0000] /root/.shardeum/docker-compose.yml: the attribute version is obsolete, it will be ignored, please remove it to avoid potential confusion

#13 removed the obsolete version from the docker-compose.yml file, but it was not removed from the template which is what is actually used so this warning was still getting thrown.

https://github.com/compose-spec/compose-spec/blob/main/spec.md#version-top-level-element-obsolete