### PR TITLE
ISSUE-36 use actual home dir 

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -7,7 +7,12 @@ environment=$(uname)
 # If the script is run as root, set the HOME variable to the user's home directory
 if [ "$EUID" -eq 0 ]; then
     ACTUAL_USER=$(logname 2>/dev/null || echo $SUDO_USER)
-    HOME="/home/$ACTUAL_USER"
+    # prefer the more secure getent if available as it prevents command injection, but fall back to ~USER if not available
+    if command -v getent 2>&1 >/dev/null; then
+      HOME=$(getent passwd "$ACTUAL_USER" | cut -d: -f6)
+    else
+      HOME=`echo ~ACTUAL_USER`
+    fi
 fi
 
 # Function to exit with an error message

--- a/installer.sh
+++ b/installer.sh
@@ -7,7 +7,7 @@ environment=$(uname)
 # If the script is run as root, set the HOME variable to the user's home directory
 if [ "$EUID" -eq 0 ]; then
     ACTUAL_USER=$(logname 2>/dev/null || echo $SUDO_USER)
-    # prefer the more secure getent if available as it prevents command injection, but fall back to ~USER if not available
+    # Use 'getent' to get home dir (6th field of passwd). If unavailable, fallback to shell expansion ~
     if command -v getent 2>&1 >/dev/null; then
       HOME=$(getent passwd "$ACTUAL_USER" | cut -d: -f6)
     else

--- a/installer.sh
+++ b/installer.sh
@@ -4,15 +4,6 @@ set -e
 # Get the environment/OS
 environment=$(uname)
 
-# Set the HOME variable to the user's home directory
-ACTUAL_USER=$(logname 2>/dev/null || echo $SUDO_USER)
-# Use 'getent' to get home dir (6th field of passwd). If unavailable, fallback to shell expansion ~
-if command -v getent 2>&1 >/dev/null; then
-  HOME=$(getent passwd "$ACTUAL_USER" | cut -d: -f6)
-else
-  HOME=`echo ~$ACTUAL_USER`
-fi
-
 # Function to exit with an error message
 exit_with_error() {
     echo "Error: $1"
@@ -120,8 +111,10 @@ input=${input// /}
 # Echo the final directory used
 echo "The base directory is set to: $input"
 
-# Replace leading tilde (~) with the actual home directory path
-NODEHOME="${input/#\~/$HOME}" # support ~ in path
+# Expand the tilde in the input if any
+NODEHOME=`realpath "${input}"`
+
+echo "Real path for directory is: $NODEHOME"
 
 # Check all things that will be needed for this script to succeed like access to docker and docker-compose
 # If any check fails, attempt to install the missing dependency

--- a/installer.sh
+++ b/installer.sh
@@ -4,15 +4,13 @@ set -e
 # Get the environment/OS
 environment=$(uname)
 
-# If the script is run as root, set the HOME variable to the user's home directory
-if [ "$EUID" -eq 0 ]; then
-    ACTUAL_USER=$(logname 2>/dev/null || echo $SUDO_USER)
-    # Use 'getent' to get home dir (6th field of passwd). If unavailable, fallback to shell expansion ~
-    if command -v getent 2>&1 >/dev/null; then
-      HOME=$(getent passwd "$ACTUAL_USER" | cut -d: -f6)
-    else
-      HOME=`echo ~ACTUAL_USER`
-    fi
+# Set the HOME variable to the user's home directory
+ACTUAL_USER=$(logname 2>/dev/null || echo $SUDO_USER)
+# Use 'getent' to get home dir (6th field of passwd). If unavailable, fallback to shell expansion ~
+if command -v getent 2>&1 >/dev/null; then
+  HOME=$(getent passwd "$ACTUAL_USER" | cut -d: -f6)
+else
+  HOME=`echo ~$ACTUAL_USER`
 fi
 
 # Function to exit with an error message


### PR DESCRIPTION
Determining the users home directory now no longer assumes it's located in /home by using either getent on linux platforms, or ~USER on others

This should resolve [ISSUE-36 ](https://github.com/shardeum/validator-dashboard/issues/36)