### PR TITLE
SYS-523 Fix custom shardeum directory

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -90,9 +90,6 @@ input=${input:-~/.shardeum}
 
 # Reprompt if not alphanumeric characters, tilde, forward slash, underscore, period, hyphen, or contains spaces
 while [[ ! $input =~ ^[[:alnum:]_.~/-]+$ || $input =~ [[:space:]] ]]; do
-#   read -p "Error: The directory name contains invalid characters or spaces.
-# Allowed characters are alphanumeric characters, tilde, forward slash, underscore, period, and hyphen.
-# Please enter a valid base directory (default ~/.shardeum): " input
   echo "Error: The directory name contains invalid characters or spaces."
   echo "Allowed characters are alphanumeric characters, tilde (~), forward slash (/), underscore (_), period (.), and hyphen (-)."
   read -p "Please enter a valid base directory (default ~/.shardeum): " input


### PR DESCRIPTION
https://linear.app/shm/issue/SYS-523/operator-installer-cannot-set-custom-directory

Anything other that defaul directory was failing. It was also always setting putting the directory in the home dir even if the user was running the script from another location and input a relative path.


Tests:
- default:
```
What base directory should the node use (default ~/.shardeum): 
The base directory is set to: /home/c/.shardeum
Real path for directory is: /home/c/.shardeum
```
- explicit tilda
```
What base directory should the node use (default ~/.shardeum): ~/.shardeum12 
The base directory is set to: ~/.shardeum12
Real path for directory is: /home/c/.shardeum12
```
- relative path 
```
What base directory should the node use (default ~/.shardeum): ./newDir123
The base directory is set to: ./newDir123
Real path for directory is: /home/c/shardeumNodes/newDir123
```
- local dir
```
What base directory should the node use (default ~/.shardeum): .newDir
The base directory is set to: .newDir
Real path for directory is: /home/c/shardeumNodes/.newDir
``` 
- root path without sudo
```
What base directory should the node use (default ~/.shardeum): /newDir
The base directory is set to: /newDir
mkdir: cannot create directory ‘/newDir’: Permission denied
```
- root path with sudo
```
What base directory should the node use (default ~/.shardeum): /rootshardeum1
The base directory is set to: /rootshardeum1
Real path for directory is: /rootshardeum1
```