### PR TITLE
Set shardeum server version to itn1.15.0-rotation-c619d62

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/shardeum/server:latest
+FROM ghcr.io/shardeum/server:itn1.15.0-rotation-c619d62
 
 ARG RUNDASHBOARD=y
 ENV RUNDASHBOARD=${RUNDASHBOARD}


### PR DESCRIPTION
Update the version of the shardeum container in the Dockerfile.

* Change the `FROM` directive in the `Dockerfile` to use `ghcr.io/shardeum/server:itn1.15.0-rotation-c619d62` instead of `ghcr.io/shardeum/server:latest`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shardeum/validator-dashboard/pull/42?shareId=44d05d89-c8d3-421c-8d4f-3c4164d9d680).