### PR TITLE
1.15.2 use latest shardeum image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/shardeum/server:itn1.15.1-rotation-fd1320b
+FROM ghcr.io/shardeum/server:latest
 
 ARG RUNDASHBOARD=y
 ENV RUNDASHBOARD=${RUNDASHBOARD}


### PR DESCRIPTION
- sets dockerfile back to using the latest image tag (currently 1.15.2)
- this will also be merged into main branch 
![image](https://github.com/user-attachments/assets/f879cdda-5c5d-4623-963f-7ab4c6b669ae)
